### PR TITLE
Fix table pipe style errors

### DIFF
--- a/docs/basic-smf-commands.md
+++ b/docs/basic-smf-commands.md
@@ -258,7 +258,7 @@ case to figure out which ipf.conf ipfilter is using:
 Using SMF to uncover information about a service is easy.
 
 <!-- markdownlint-disable line-length -->
-| Command          | Description
+| Command          | Description |
 | ---------------- | ----------------------------------------------------- |
 | `svcs -a`        | List all services for this SmartMachine, including disabled services. |
 | `svcs -x`        | List explanations for all services that are running but not enabled or services that are preventing another service from running. |

--- a/docs/the-linux-to-smartos-cheat-sheet.md
+++ b/docs/the-linux-to-smartos-cheat-sheet.md
@@ -1228,7 +1228,7 @@ For example, here are some common Linux commands that work differently.
 <!-- markdownlint-disable line-length -->
 
 | Command | What's different on a Smart Machine |
-| ------- | ------------------------------------------------------------
+| ------- | ------------------------------------------------------------ |
 | `df`    | On most SmartOS image this is set up to use the GNU version. Use `/usr/bin/df` for the native version. |
 | `lsof`  | SmartMachines use a different collection of tools to examine processes. See [Examining processes and memory](#examining-processes-and-memory) later in this topic. |
 | `ping`  | Returns whether a host responds or not.  Use `ping -s` to get a continuous response.   |
@@ -1248,7 +1248,7 @@ more about them by looking at the `proc` man page.
 <!-- markdownlint-disable line-length -->
 
 | Tool       | Description |
-| ---------- | ---------------------------------------------------------
+| ---------- | --------------------------------------------------------- |
 | `prstat`   | This tool displays the active processes like `top` does on Linux systems. `prstat -Z` will provide you with a summary of your instance's status. |
 | `pgrep`    | Returns a list of process IDs (PIDs) of processes that match a pattern or meet certain conditions. |
 | `pkill`    | Kills the processes that match a pattern or meet certain conditions. |


### PR DESCRIPTION
This fixes the `make check` complaints about some of the tables missing trailing pipes.

QA: `make check` reports 0 errors after applying these changes, and the tables look fine in a browser via `make serve`.