### PR TITLE
Remove defunct baremetalcloud.com link in community-experiments.md

### DIFF
--- a/docs/community-experiments.md
+++ b/docs/community-experiments.md
@@ -35,4 +35,3 @@ on your own!
 **Blog posts, etc:**
 
 - [Run Things at Boot](http://www.psychicfriends.net/blog/archives/2012/03/21/smartosorg_run_things_at_boot.html)
-- [Creating and deploying a SmartOS image at bare**metal**cloud](http://documentation.baremetalcloud.com/display/bmc/SmartOS)


### PR DESCRIPTION
```console
$ host documentation.baremetalcloud.com
Host documentation.baremetalcloud.com not found: 3(NXDOMAIN)

$ host baremetalcloud.com
baremetalcloud.com has address 199.34.120.34

$ curl https://baremetalcloud.com
(timeout)
```

